### PR TITLE
Sparkrun registry scaffolding

### DIFF
--- a/.sparkrun/registry.yaml
+++ b/.sparkrun/registry.yaml
@@ -1,0 +1,11 @@
+registries:
+  - name: official
+    description: Official Spark Arena registry for recipes, tuning configs, and benchmark profiles
+    recipes: official-recipes
+    tuning: tuning
+    benchmarks: benchmarking
+
+  - name: experimental
+    description: Spark Arena registry for experimental recipes
+    recipes: experimental-recipes
+    visible: false

--- a/benchmarking/README.md
+++ b/benchmarking/README.md
@@ -1,0 +1,5 @@
+# Benchmark Profiles
+
+Official Spark Arena benchmarking profile definitions for sparkrun. These profiles define standardized
+test configurations for evaluating LLM inference performance on DGX Spark.
+

--- a/benchmarking/spark-arena-v1.yaml
+++ b/benchmarking/spark-arena-v1.yaml
@@ -1,0 +1,9 @@
+framework: llama-benchy
+metadata:
+  description: Spark Arena Benchmark Profile v1
+args:
+  depth: [ 0, 4096, 8192, 16384, 32768, 65535, 100000 ]
+  pp: [ 2048 ]
+  tg: [ 128 ]
+  concurrency: [ 1, 2, 5, 10 ]
+  prefix_caching: true

--- a/experimental-recipes/README.md
+++ b/experimental-recipes/README.md
@@ -1,0 +1,13 @@
+# Recipes
+
+  Experimental inference recipe definitions. Each recipe is a YAML file that
+  specifies a model, container image, runtime, and default configuration for
+  launching LLM inference on DGX Spark. 
+
+  These recipes have not been tested as extensively as the official recipes.
+
+  ## Usage
+
+      sparkrun recipe list
+      sparkrun recipe show <recipe>
+      sparkrun run <recipe>

--- a/official-recipes/README.md
+++ b/official-recipes/README.md
@@ -1,0 +1,13 @@
+# Recipes
+
+  Official inference recipe definitions. Each recipe is a YAML file that
+  specifies a model, container image, runtime, and default configuration for
+  launching LLM inference on DGX Spark.
+
+  These recipes have been tested and are recommended for production use.
+
+  ## Usage
+
+      sparkrun recipe list
+      sparkrun recipe show <recipe>
+      sparkrun run <recipe>

--- a/tuning/README.md
+++ b/tuning/README.md
@@ -1,0 +1,10 @@
+# Tuning Configs
+
+Pre-computed Triton fused MoE kernel tuning configurations for DGX Spark.
+
+These configs are automatically synced and mounted when running recipes
+that benefit from tuned kernels. Generate your own with:
+
+    sparkrun tune sglang <recipe> -H <host>
+    sparkrun tune vllm <recipe> -H <host>
+


### PR DESCRIPTION
As part of work on formalizing registries for sparkrun, here is a draft registry configuration/scaffolding to be placed in spark-arena official registry. 

- Recipe files should be placed in defined recipes directory.  (required)
- Tuning files should be placed in defined tuning directory. (optional)
- Benchmarking profiles should be placed in defined benchmarking directory. (optional)

Registry definition files are designed to enable adding registries as: 
`sparkrun registry add <repo-url>`

The Spark Arena git-based registry will be the official registry included by default on installation of sparkrun. 