### PR TITLE
Add qwen3-coder-next-int4-autoround-vllm, qwen3-vl-embedding-8b-vllm, qwen3-vl-reranker-8b-vllm

### DIFF
--- a/official-recipes/qwen3-coder-next/vllm/qwen3-coder-next-int4-autoround-vllm.yaml
+++ b/official-recipes/qwen3-coder-next/vllm/qwen3-coder-next-int4-autoround-vllm.yaml
@@ -1,0 +1,46 @@
+recipe_version: "2"
+model: Intel/Qwen3-Coder-Next-int4-AutoRound
+runtime: vllm
+max_nodes: 1
+container: ghcr.io/spark-arena/dgx-vllm-eugr-nightly-tf5:latest
+
+metadata:
+  description: Qwen3-Coder-Next-int4-Autoround
+
+mods:
+  - mods/fix-qwen3-next-autoround
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  gpu_memory_utilization: 0.7
+  max_model_len: 262144
+  tool_call_parser: qwen3_coder
+  max_num_seqs: 128
+  max_num_batched_tokens: 16384
+  kv_cache_dtype: fp8
+  optimization_level: 3
+  performance_mode: throughput
+  mamba_cache_mode: align
+
+env:
+  VLLM_MARLIN_USE_ATOMIC_ADD: "1"
+  VLLM_SLEEP_WHEN_IDLE: "0"
+
+command: |
+  vllm serve {model} \
+    --enable-auto-tool-choice \
+    --tool-call-parser {tool_call_parser} \
+    --gpu-memory-utilization {gpu_memory_utilization} \
+    --host {host} \
+    --port {port} \
+    --load-format fastsafetensors \
+    --enable-prefix-caching \
+    --enable-chunked-prefill \
+    --max-model-len {max_model_len} \
+    --max-num-seqs {max_num_seqs} \
+    --max-num-batched-tokens {max_num_batched_tokens} \
+    --kv-cache-dtype {kv_cache_dtype} \
+    --optimization-level {optimization_level} \
+    --performance-mode {performance_mode} \
+    --mamba-cache-mode {mamba_cache_mode}

--- a/official-recipes/qwen3-vl/vllm/qwen3-vl-embedding-8b-vllm.yaml
+++ b/official-recipes/qwen3-vl/vllm/qwen3-vl-embedding-8b-vllm.yaml
@@ -1,0 +1,26 @@
+recipe_version: "2"
+model: Qwen/Qwen3-VL-Embedding-8B
+runtime: vllm
+max_nodes: 1
+container: ghcr.io/spark-arena/dgx-vllm-eugr-nightly-tf5:latest
+
+metadata:
+  description: Qwen3-VL-Embedding-8B — vision-language embedding model for multimodal retrieval
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 1
+  gpu_memory_utilization: 0.3
+  max_model_len: 32768
+
+command: |
+  vllm serve {model} \
+    --runner pooling \
+    --gpu-memory-utilization {gpu_memory_utilization} \
+    -tp {tensor_parallel} \
+    --host {host} \
+    --port {port} \
+    --max-model-len {max_model_len} \
+    --load-format fastsafetensors \
+    --trust-remote-code

--- a/official-recipes/qwen3-vl/vllm/qwen3-vl-reranker-8b-vllm.yaml
+++ b/official-recipes/qwen3-vl/vllm/qwen3-vl-reranker-8b-vllm.yaml
@@ -1,0 +1,26 @@
+recipe_version: "2"
+model: Qwen/Qwen3-VL-Reranker-8B
+runtime: vllm
+max_nodes: 1
+container: ghcr.io/spark-arena/dgx-vllm-eugr-nightly-tf5:latest
+
+metadata:
+  description: Qwen3-VL-Reranker-8B — vision-language reranker model for multimodal retrieval
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 1
+  gpu_memory_utilization: 0.3
+  max_model_len: 32768
+
+command: |
+  vllm serve {model} \
+    --runner pooling \
+    --gpu-memory-utilization {gpu_memory_utilization} \
+    -tp {tensor_parallel} \
+    --host {host} \
+    --port {port} \
+    --max-model-len {max_model_len} \
+    --load-format fastsafetensors \
+    --trust-remote-code


### PR DESCRIPTION
**New Qwen3 Model Recipes:**

*Qwen3 Coder Model:*
- Added `qwen3-coder-next-int4-autoround-vllm.yaml` for the `Intel/Qwen3-Coder-Next-int4-AutoRound` model, including performance-focused defaults, environment variables, and command-line options for efficient code generation and tool integration.

*Qwen3 Vision-Language Models:*
- Added `qwen3-vl-embedding-8b-vllm.yaml` for the `Qwen/Qwen3-VL-Embedding-8B` vision-language embedding model, optimized for multimodal retrieval tasks, with pooling runner and trust-remote-code enabled.
- Added `qwen3-vl-reranker-8b-vllm.yaml` for the `Qwen/Qwen3-VL-Reranker-8B` vision-language reranker model, similarly configured for multimodal retrieval with pooling runner and resource-efficient defaults.