### PR TITLE
experimental converted eugr repo recipes 

### DIFF
--- a/experimental-recipes/eugr-vllm/glm-4.7-flash-awq-vllm.yaml
+++ b/experimental-recipes/eugr-vllm/glm-4.7-flash-awq-vllm.yaml
@@ -1,0 +1,34 @@
+recipe_version: "2"
+model: cyankiwi/GLM-4.7-Flash-AWQ-4bit
+runtime: vllm
+container: ghcr.io/spark-arena/dgx-vllm-eugr-nightly-tf5:latest
+
+metadata:
+  description: GLM-4.7-Flash-AWQ — cyankiwi AWQ quantized GLM-4.7-Flash with speed optimization patch
+
+mods:
+  - mods/fix-glm-4.7-flash-AWQ
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 1
+  gpu_memory_utilization: 0.7
+  max_model_len: 202752
+  max_num_batched_tokens: 4096
+  max_num_seqs: 64
+  served_model_name: glm-4.7-flash
+
+command: |
+  vllm serve {model} \
+    --tool-call-parser glm47 \
+    --reasoning-parser glm45 \
+    --enable-auto-tool-choice \
+    --served-model-name {served_model_name} \
+    --max-model-len {max_model_len} \
+    --max-num-batched-tokens {max_num_batched_tokens} \
+    --max-num-seqs {max_num_seqs} \
+    --gpu-memory-utilization {gpu_memory_utilization} \
+    -tp {tensor_parallel} \
+    --host {host} \
+    --port {port}

--- a/experimental-recipes/eugr-vllm/minimax-m2-awq-vllm.yaml
+++ b/experimental-recipes/eugr-vllm/minimax-m2-awq-vllm.yaml
@@ -1,0 +1,27 @@
+recipe_version: "2"
+model: QuantTrio/MiniMax-M2-AWQ
+runtime: vllm
+min_nodes: 2
+container: ghcr.io/spark-arena/dgx-vllm-eugr-nightly:latest
+
+metadata:
+  description: MiniMax-M2-AWQ — AWQ quantized MiniMax M2
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 2
+  gpu_memory_utilization: 0.7
+  max_model_len: 128000
+
+command: |
+  vllm serve {model} \
+    --gpu-memory-utilization {gpu_memory_utilization} \
+    -tp {tensor_parallel} \
+    --max-model-len {max_model_len} \
+    --load-format fastsafetensors \
+    --enable-auto-tool-choice \
+    --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2 \
+    --host {host} \
+    --port {port}

--- a/experimental-recipes/eugr-vllm/minimax-m2.5-4x-vllm.yaml
+++ b/experimental-recipes/eugr-vllm/minimax-m2.5-4x-vllm.yaml
@@ -1,0 +1,31 @@
+recipe_version: "2"
+model: MiniMaxAI/MiniMax-M2.5
+runtime: vllm
+min_nodes: 4
+container: ghcr.io/spark-arena/dgx-vllm-eugr-nightly:latest
+
+metadata:
+  description: MiniMax-M2.5 — full precision, TP=4 across 4 DGX Spark nodes
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 4
+  gpu_memory_utilization: 0.90
+  max_model_len: 128000
+
+env:
+  VLLM_DISTRIBUTED_EXECUTOR_CONFIG: '{"placement_group_options":{"strategy":"SPREAD"}}'
+
+command: |
+  vllm serve {model} \
+    --trust-remote-code \
+    --gpu-memory-utilization {gpu_memory_utilization} \
+    -tp {tensor_parallel} \
+    --max-model-len {max_model_len} \
+    --load-format fastsafetensors \
+    --enable-auto-tool-choice \
+    --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2_append_think \
+    --host {host} \
+    --port {port}

--- a/experimental-recipes/eugr-vllm/minimax-m2.5-awq-vllm.yaml
+++ b/experimental-recipes/eugr-vllm/minimax-m2.5-awq-vllm.yaml
@@ -1,0 +1,28 @@
+recipe_version: "2"
+model: cyankiwi/MiniMax-M2.5-AWQ-4bit
+runtime: vllm
+min_nodes: 2
+container: ghcr.io/spark-arena/dgx-vllm-eugr-nightly:latest
+
+metadata:
+  description: MiniMax-M2.5-AWQ — AWQ quantized MiniMax M2.5
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 2
+  gpu_memory_utilization: 0.7
+  max_model_len: 128000
+
+command: |
+  vllm serve {model} \
+    --trust-remote-code \
+    --gpu-memory-utilization {gpu_memory_utilization} \
+    -tp {tensor_parallel} \
+    --max-model-len {max_model_len} \
+    --load-format fastsafetensors \
+    --enable-auto-tool-choice \
+    --tool-call-parser minimax_m2 \
+    --reasoning-parser minimax_m2 \
+    --host {host} \
+    --port {port}

--- a/experimental-recipes/eugr-vllm/nemotron-3-nano-nvfp4-vllm.yaml
+++ b/experimental-recipes/eugr-vllm/nemotron-3-nano-nvfp4-vllm.yaml
@@ -1,0 +1,34 @@
+recipe_version: "2"
+model: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4
+runtime: vllm
+max_nodes: 1
+container: ghcr.io/spark-arena/dgx-vllm-eugr-nightly:latest
+
+metadata:
+  description: Nemotron-3-Nano NVFP4 — single node only
+
+mods:
+  - mods/nemotron-nano
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 1
+  gpu_memory_utilization: 0.7
+  max_model_len: 262144
+
+command: |
+  vllm serve {model} \
+    --moe-backend cutlass \
+    --max-model-len {max_model_len} \
+    --host {host} \
+    --port {port} \
+    --trust-remote-code \
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_coder \
+    --reasoning-parser-plugin nano_v3_reasoning_parser.py \
+    --reasoning-parser nano_v3 \
+    --kv-cache-dtype fp8 \
+    --enable-prefix-caching \
+    --load-format fastsafetensors \
+    --gpu-memory-utilization {gpu_memory_utilization}

--- a/experimental-recipes/eugr-vllm/nemotron-3-super-nvfp4-vllm.yaml
+++ b/experimental-recipes/eugr-vllm/nemotron-3-super-nvfp4-vllm.yaml
@@ -1,0 +1,36 @@
+recipe_version: "2"
+model: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4
+runtime: vllm
+container: ghcr.io/spark-arena/dgx-vllm-eugr-nightly:latest
+
+metadata:
+  description: Nemotron-3-Super NVFP4 — CUTLASS kernels optimized
+
+mods:
+  - mods/nemotron-super
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 1
+  gpu_memory_utilization: 0.7
+  max_model_len: 262144
+  max_num_seqs: 10
+
+command: |
+  vllm serve {model} \
+    --kv-cache-dtype fp8 \
+    --moe-backend cutlass \
+    --trust-remote-code \
+    --gpu-memory-utilization {gpu_memory_utilization} \
+    --max-model-len {max_model_len} \
+    --max-num-seqs {max_num_seqs} \
+    --enable-prefix-caching \
+    --host {host} \
+    --port {port} \
+    --enable-auto-tool-choice \
+    --load-format fastsafetensors \
+    --tool-call-parser qwen3_coder \
+    --reasoning-parser-plugin super_v3_reasoning_parser.py \
+    --reasoning-parser super_v3 \
+    --tensor-parallel-size {tensor_parallel}

--- a/experimental-recipes/eugr-vllm/openai-gpt-oss-120b-vllm.yaml
+++ b/experimental-recipes/eugr-vllm/openai-gpt-oss-120b-vllm.yaml
@@ -1,0 +1,36 @@
+recipe_version: "2"
+model: openai/gpt-oss-120b
+runtime: vllm
+min_nodes: 2
+container: ghcr.io/spark-arena/dgx-vllm-eugr-nightly:latest
+
+metadata:
+  description: OpenAI GPT-OSS 120B — MXFP4 quantization with FlashInfer
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 2
+  gpu_memory_utilization: 0.70
+  max_num_batched_tokens: 8192
+
+env:
+  VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8: "1"
+
+command: |
+  vllm serve {model} \
+    --tool-call-parser openai \
+    --reasoning-parser openai_gptoss \
+    --enable-auto-tool-choice \
+    --tensor-parallel-size {tensor_parallel} \
+    --gpu-memory-utilization {gpu_memory_utilization} \
+    --enable-prefix-caching \
+    --load-format fastsafetensors \
+    --quantization mxfp4 \
+    --mxfp4-backend CUTLASS \
+    --mxfp4-layers moe,qkv,o,lm_head \
+    --attention-backend FLASHINFER \
+    --kv-cache-dtype fp8 \
+    --max-num-batched-tokens {max_num_batched_tokens} \
+    --host {host} \
+    --port {port}

--- a/experimental-recipes/eugr-vllm/openai-gpt-oss-120b-vllm.yaml
+++ b/experimental-recipes/eugr-vllm/openai-gpt-oss-120b-vllm.yaml
@@ -2,7 +2,10 @@ recipe_version: "2"
 model: openai/gpt-oss-120b
 runtime: vllm
 min_nodes: 2
-container: ghcr.io/spark-arena/dgx-vllm-eugr-nightly:latest
+container: vllm-node-mxfp4
+
+build_args:
+  - "--exp-mxfp4"
 
 metadata:
   description: OpenAI GPT-OSS 120B — MXFP4 quantization with FlashInfer

--- a/experimental-recipes/eugr-vllm/qwen3-coder-next-fp8-vllm.yaml
+++ b/experimental-recipes/eugr-vllm/qwen3-coder-next-fp8-vllm.yaml
@@ -1,0 +1,31 @@
+recipe_version: "2"
+model: Qwen/Qwen3-Coder-Next-FP8
+runtime: vllm
+container: ghcr.io/spark-arena/dgx-vllm-eugr-nightly:latest
+
+metadata:
+  description: Qwen3-Coder-Next-FP8 — native FP8 format
+
+mods:
+  - mods/fix-qwen3-coder-next
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 1
+  gpu_memory_utilization: 0.7
+  max_model_len: 131072
+
+command: |
+  vllm serve {model} \
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_coder \
+    --gpu-memory-utilization {gpu_memory_utilization} \
+    --host {host} \
+    --port {port} \
+    --kv-cache-dtype fp8 \
+    --load-format fastsafetensors \
+    --attention-backend flashinfer \
+    --enable-prefix-caching \
+    --max-model-len {max_model_len} \
+    -tp {tensor_parallel}

--- a/experimental-recipes/eugr-vllm/qwen3-coder-next-int4-autoround-vllm.yaml
+++ b/experimental-recipes/eugr-vllm/qwen3-coder-next-int4-autoround-vllm.yaml
@@ -1,0 +1,32 @@
+recipe_version: "2"
+model: Intel/Qwen3-Coder-Next-int4-AutoRound
+runtime: vllm
+max_nodes: 1
+container: ghcr.io/spark-arena/dgx-vllm-eugr-nightly:latest
+
+metadata:
+  description: Qwen3-Coder-Next INT4-AutoRound — solo node only
+
+mods:
+  - mods/fix-qwen3-next-autoround
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 1
+  gpu_memory_utilization: 0.7
+  max_model_len: 262144
+
+env:
+  VLLM_MARLIN_USE_ATOMIC_ADD: "1"
+
+command: |
+  vllm serve {model} \
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_coder \
+    --gpu-memory-utilization {gpu_memory_utilization} \
+    --host {host} \
+    --port {port} \
+    --load-format fastsafetensors \
+    --enable-prefix-caching \
+    --max-model-len {max_model_len}

--- a/experimental-recipes/eugr-vllm/qwen3.5-122b-a10b-fp8-vllm.yaml
+++ b/experimental-recipes/eugr-vllm/qwen3.5-122b-a10b-fp8-vllm.yaml
@@ -1,0 +1,34 @@
+recipe_version: "2"
+model: Qwen/Qwen3.5-122B-A10B-FP8
+runtime: vllm
+min_nodes: 2
+container: ghcr.io/spark-arena/dgx-vllm-eugr-nightly:latest
+
+metadata:
+  description: Qwen3.5-122B-A10B-FP8 — native FP8 format
+
+mods:
+  - mods/fix-qwen3.5-chat-template
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 2
+  gpu_memory_utilization: 0.7
+  max_model_len: 262144
+  max_num_batched_tokens: 8192
+
+command: |
+  vllm serve {model} \
+    --max-model-len {max_model_len} \
+    --gpu-memory-utilization {gpu_memory_utilization} \
+    --host {host} \
+    --port {port} \
+    --load-format fastsafetensors \
+    --enable-prefix-caching \
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_coder \
+    --reasoning-parser qwen3 \
+    --chat-template unsloth.jinja \
+    -tp {tensor_parallel} \
+    --max-num-batched-tokens {max_num_batched_tokens}

--- a/experimental-recipes/eugr-vllm/qwen3.5-122b-a10b-int4-autoround-vllm.yaml
+++ b/experimental-recipes/eugr-vllm/qwen3.5-122b-a10b-int4-autoround-vllm.yaml
@@ -1,0 +1,38 @@
+recipe_version: "2"
+model: Intel/Qwen3.5-122B-A10B-int4-AutoRound
+runtime: vllm
+container: ghcr.io/spark-arena/dgx-vllm-eugr-nightly-tf5:latest
+
+metadata:
+  description: Qwen3.5-122B-A10B INT4-AutoRound
+
+mods:
+  - mods/fix-qwen3.5-autoround
+  - mods/fix-qwen3.5-chat-template
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 1
+  gpu_memory_utilization: 0.7
+  max_model_len: 262144
+  max_num_batched_tokens: 8192
+
+env:
+  VLLM_MARLIN_USE_ATOMIC_ADD: "1"
+
+command: |
+  vllm serve {model} \
+    --max-model-len {max_model_len} \
+    --gpu-memory-utilization {gpu_memory_utilization} \
+    --host {host} \
+    --port {port} \
+    --load-format fastsafetensors \
+    --enable-prefix-caching \
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_coder \
+    --reasoning-parser qwen3 \
+    --max-num-batched-tokens {max_num_batched_tokens} \
+    --trust-remote-code \
+    --chat-template unsloth.jinja \
+    -tp {tensor_parallel}

--- a/experimental-recipes/eugr-vllm/qwen3.5-35b-a3b-fp8-vllm.yaml
+++ b/experimental-recipes/eugr-vllm/qwen3.5-35b-a3b-fp8-vllm.yaml
@@ -1,0 +1,38 @@
+recipe_version: "2"
+model: Qwen/Qwen3.5-35B-A3B-FP8
+runtime: vllm
+container: ghcr.io/spark-arena/dgx-vllm-eugr-nightly:latest
+
+metadata:
+  description: Qwen3.5-35B-A3B-FP8 — native FP8 format
+
+mods:
+  - mods/fix-qwen3-coder-next
+  - mods/fix-qwen3.5-chat-template
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 1
+  gpu_memory_utilization: 0.7
+  max_model_len: 262144
+  max_num_batched_tokens: 16384
+
+env:
+  VLLM_MARLIN_USE_ATOMIC_ADD: "1"
+
+command: |
+  vllm serve {model} \
+    --host {host} \
+    --port {port} \
+    --max-model-len {max_model_len} \
+    --max-num-batched-tokens {max_num_batched_tokens} \
+    --gpu-memory-utilization {gpu_memory_utilization} \
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_coder \
+    --kv-cache-dtype fp8 \
+    --load-format fastsafetensors \
+    --attention-backend flashinfer \
+    --enable-prefix-caching \
+    --chat-template unsloth.jinja \
+    -tp {tensor_parallel}

--- a/experimental-recipes/eugr-vllm/qwen3.5-397b-a17b-fp8-4x-vllm.yaml
+++ b/experimental-recipes/eugr-vllm/qwen3.5-397b-a17b-fp8-4x-vllm.yaml
@@ -1,0 +1,45 @@
+recipe_version: "2"
+model: Qwen/Qwen3.5-397B-A17B-FP8
+runtime: vllm
+min_nodes: 4
+container: ghcr.io/spark-arena/dgx-vllm-eugr-nightly-tf5:latest
+
+metadata:
+  description: Qwen3.5-397B-A17B-FP8 — TP=4 across 4 DGX Spark nodes
+
+mods:
+  - mods/fix-qwen3.5-autoround
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 4
+  gpu_memory_utilization: 0.85
+  max_model_len: 262144
+  max_num_batched_tokens: 8192
+
+env:
+  VLLM_USE_DEEP_GEMM: "0"
+  VLLM_USE_FLASHINFER_MOE_FP16: "1"
+  VLLM_USE_FLASHINFER_SAMPLER: "0"
+  OMP_NUM_THREADS: "4"
+
+command: |
+  vllm serve {model} \
+    --max-model-len {max_model_len} \
+    --gpu-memory-utilization {gpu_memory_utilization} \
+    --host {host} \
+    --port {port} \
+    --load-format fastsafetensors \
+    --enable-prefix-caching \
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_coder \
+    --reasoning-parser qwen3 \
+    --max-num-batched-tokens {max_num_batched_tokens} \
+    --trust-remote-code \
+    -tp {tensor_parallel} \
+    --mm-encoder-tp-mode data \
+    --kv-cache-dtype fp8 \
+    --compilation-config.cudagraph_mode none \
+    --max-num-seqs 32 \
+    --attention-backend flashinfer

--- a/experimental-recipes/eugr-vllm/qwen3.5-397b-a17b-fp8-4x-vllm.yaml
+++ b/experimental-recipes/eugr-vllm/qwen3.5-397b-a17b-fp8-4x-vllm.yaml
@@ -2,6 +2,7 @@ recipe_version: "2"
 model: Qwen/Qwen3.5-397B-A17B-FP8
 runtime: vllm
 min_nodes: 4
+max_nodes: 4
 container: ghcr.io/spark-arena/dgx-vllm-eugr-nightly-tf5:latest
 
 metadata:

--- a/experimental-recipes/eugr-vllm/qwen3.5-397b-a17b-int4-autoround-2x-vllm.yaml
+++ b/experimental-recipes/eugr-vllm/qwen3.5-397b-a17b-int4-autoround-2x-vllm.yaml
@@ -2,6 +2,7 @@ recipe_version: "2"
 model: Intel/Qwen3.5-397B-A17B-int4-AutoRound
 runtime: vllm
 min_nodes: 2
+max_nodes: 2
 container: ghcr.io/spark-arena/dgx-vllm-eugr-nightly-tf5:latest
 
 metadata:

--- a/experimental-recipes/eugr-vllm/qwen3.5-397b-a17b-int4-autoround-4x-vllm.yaml
+++ b/experimental-recipes/eugr-vllm/qwen3.5-397b-a17b-int4-autoround-4x-vllm.yaml
@@ -2,6 +2,7 @@ recipe_version: "2"
 model: Intel/Qwen3.5-397B-A17B-int4-AutoRound
 runtime: vllm
 min_nodes: 4
+max_nodes: 4
 container: ghcr.io/spark-arena/dgx-vllm-eugr-nightly-tf5:latest
 
 metadata:

--- a/experimental-recipes/eugr-vllm/qwen3.5-397b-a17b-int4-autoround-4x-vllm.yaml
+++ b/experimental-recipes/eugr-vllm/qwen3.5-397b-a17b-int4-autoround-4x-vllm.yaml
@@ -1,0 +1,39 @@
+recipe_version: "2"
+model: Intel/Qwen3.5-397B-A17B-int4-AutoRound
+runtime: vllm
+min_nodes: 4
+container: ghcr.io/spark-arena/dgx-vllm-eugr-nightly-tf5:latest
+
+metadata:
+  description: Qwen3.5-397B-A17B INT4-AutoRound — TP=4 across 4 DGX Spark nodes (Marlin fix applied)
+
+mods:
+  - mods/fix-qwen3-coder-next
+  - mods/fix-qwen35-tp4-marlin
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 4
+  gpu_memory_utilization: 0.78
+  max_model_len: 32768
+  max_num_batched_tokens: 8192
+
+env:
+  VLLM_MARLIN_USE_ATOMIC_ADD: "1"
+  PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"
+
+command: |
+  vllm serve {model} \
+    --tool-call-parser qwen3_coder \
+    --reasoning-parser qwen3 \
+    --enable-auto-tool-choice \
+    --tensor-parallel-size {tensor_parallel} \
+    --kv-cache-dtype fp8 \
+    --gpu-memory-utilization {gpu_memory_utilization} \
+    --max-model-len {max_model_len} \
+    --max-num-batched-tokens {max_num_batched_tokens} \
+    --enable-prefix-caching \
+    --trust-remote-code \
+    --host {host} \
+    --port {port}

--- a/experimental-recipes/eugr-vllm/qwen3.5-397b-a17b-int4-autoround-vllm.yaml
+++ b/experimental-recipes/eugr-vllm/qwen3.5-397b-a17b-int4-autoround-vllm.yaml
@@ -1,0 +1,42 @@
+recipe_version: "2"
+model: Intel/Qwen3.5-397B-A17B-int4-AutoRound
+runtime: vllm
+min_nodes: 2
+container: ghcr.io/spark-arena/dgx-vllm-eugr-nightly-tf5:latest
+
+metadata:
+  description: Qwen3.5-397B-A17B INT4-AutoRound — TP=2 with gpu-memory-utilization in GB mode
+
+mods:
+  - mods/fix-qwen3.5-autoround
+  - mods/fix-qwen3.5-chat-template
+  - mods/gpu-mem-util-gb
+
+defaults:
+  port: 8000
+  host: 0.0.0.0
+  tensor_parallel: 2
+  gpu_memory_utilization: 112
+  max_model_len: 262144
+  max_num_batched_tokens: 4176
+
+env:
+  PYTORCH_CUDA_ALLOC_CONF: "expandable_segments:True"
+  VLLM_MARLIN_USE_ATOMIC_ADD: "1"
+
+command: |
+  vllm serve {model} \
+    --max-model-len {max_model_len} \
+    --max-num-seqs 2 \
+    --kv-cache-dtype fp8 \
+    --gpu-memory-utilization-gb {gpu_memory_utilization} \
+    --host {host} \
+    --port {port} \
+    --enable-prefix-caching \
+    --enable-auto-tool-choice \
+    --tool-call-parser qwen3_coder \
+    --reasoning-parser qwen3 \
+    --max-num-batched-tokens {max_num_batched_tokens} \
+    --trust-remote-code \
+    --chat-template unsloth.jinja \
+    -tp {tensor_parallel}


### PR DESCRIPTION
This pull request adds eugr's set of VLLM recipe YAMLs for deploying and serving a variety of large language models with different quantization and optimization strategies. The recipes cover models from Qwen, MiniMax, OpenAI, NVIDIA, and GLM, and include support for various tensor parallelism, quantization formats (FP8, INT4, MXFP4, AWQ), and distributed configurations. The changes enable more flexible, efficient, and scalable model serving options for different hardware and deployment scenarios.

The most important changes are:

**Qwen3.5 and Qwen3 Model Recipes:**
- Added recipes for Qwen3.5-397B, Qwen3.5-122B, and Qwen3.5-35B models in both FP8 and INT4-AutoRound formats, supporting multi-node and tensor parallelism configurations, with various memory and backend optimizations. [[1]](diffhunk://#diff-ed9899b00dd0f89078052029fb2c23d91b891dcb4fe4aa74efeb2ce1c401e3feR1-R46) [[2]](diffhunk://#diff-09c0cb93ca4ab93c1406b9ac07f4a9ab88228b595c494de8aec12588ada7e219R1-R40) [[3]](diffhunk://#diff-2c86cf32fa104ce8238fc9c528066e5bf38acdc86a2c5e283f870b805b0cbafcR1-R43) [[4]](diffhunk://#diff-1a8d6406ed532c0a8a56875735e3ee730be3304ba266c2946a01f5f61e6d8dfeR1-R34) [[5]](diffhunk://#diff-a38ed5199807c612c639a35450e36f121c7337e621452f750a3be9f1a67eafc5R1-R38) [[6]](diffhunk://#diff-0d6ec102778deac163f7e3fd718e692975e85c2f3baeb904f7c67bca21b31db2R1-R38)
- Added recipes for Qwen3-Coder-Next in both FP8 and INT4-AutoRound quantizations, with relevant model fixes and environment settings. [[1]](diffhunk://#diff-d6c1f189fb20959386c36f17866d47b7ba76838da61c3a6c01cad955d03975a7R1-R31) [[2]](diffhunk://#diff-02f55cc7309db0727267bca410e00a14a16ab3ca37e36ab6541ee2af7815e45aR1-R32)

**MiniMax Model Recipes:**
- Introduced recipes for MiniMax-M2 and MiniMax-M2.5 models, including AWQ quantized and full precision versions, with support for multi-node and tensor parallelism. [[1]](diffhunk://#diff-1790525ad65fbb3fb6b4cbd558dc0ef58aad8c84f6bc27e34ad3015bde5020eaR1-R27) [[2]](diffhunk://#diff-ddddca65fd335aa7e4ffdcd9b7a85a63dbcc6d4ceef2c635c5dcabd49c698797R1-R28) [[3]](diffhunk://#diff-cf5f85917651794a3015b93df3a3832283d62f4a912d9549356bd34b5501a7d8R1-R31)

**NVIDIA Nemotron Model Recipes:**
- Added recipes for NVIDIA Nemotron-3-Nano and Nemotron-3-Super models in NVFP4 format, optimized for single-node and multi-node deployments, with CUTLASS kernels and FP8 kv-cache support. [[1]](diffhunk://#diff-f336ada664fa0f5f3acc54642d4d769e90a146ee8c1de8da1443809dade0b92fR1-R34) [[2]](diffhunk://#diff-413ffda73a49972766353d40c02389ec57a609f4d554cadd1fd04c48641da8b4R1-R36)

**OpenAI GPT-OSS Model Recipe:**
- Provided a recipe for OpenAI GPT-OSS 120B with MXFP4 quantization and FlashInfer attention backend, supporting multi-node and advanced quantization options.

**GLM Model Recipe:**
- Added a recipe for GLM-4.7-Flash-AWQ-4bit model with speed optimization and custom tool/reasoning parsers.