### PR TITLE
experimental: glm-4.7-flash-awq-vllm.yaml

### DIFF
--- a/experimental-recipes/eugr-vllm/glm-4.7-flash-awq-vllm.yaml
+++ b/experimental-recipes/eugr-vllm/glm-4.7-flash-awq-vllm.yaml
@@ -17,14 +17,12 @@ defaults:
   max_model_len: 202752
   max_num_batched_tokens: 4096
   max_num_seqs: 64
-  served_model_name: glm-4.7-flash
 
 command: |
   vllm serve {model} \
     --tool-call-parser glm47 \
     --reasoning-parser glm45 \
     --enable-auto-tool-choice \
-    --served-model-name {served_model_name} \
     --max-model-len {max_model_len} \
     --max-num-batched-tokens {max_num_batched_tokens} \
     --max-num-seqs {max_num_seqs} \

--- a/experimental-recipes/eugr-vllm/glm-4.7-flash-awq-vllm.yaml
+++ b/experimental-recipes/eugr-vllm/glm-4.7-flash-awq-vllm.yaml
@@ -4,7 +4,7 @@ runtime: vllm
 container: ghcr.io/spark-arena/dgx-vllm-eugr-nightly-tf5:latest
 
 metadata:
-  description: GLM-4.7-Flash-AWQ — cyankiwi AWQ quantized GLM-4.7-Flash with speed optimization patch
+  description: GLM-4.7-Flash-AWQ — cyankiwi AWQ quantized GLM-4.7-Flash
 
 # This mod applied MLA patch, but doesn't apply after vllm 0.14.1
 #mods:

--- a/experimental-recipes/eugr-vllm/glm-4.7-flash-awq-vllm.yaml
+++ b/experimental-recipes/eugr-vllm/glm-4.7-flash-awq-vllm.yaml
@@ -6,8 +6,9 @@ container: ghcr.io/spark-arena/dgx-vllm-eugr-nightly-tf5:latest
 metadata:
   description: GLM-4.7-Flash-AWQ — cyankiwi AWQ quantized GLM-4.7-Flash with speed optimization patch
 
-mods:
-  - mods/fix-glm-4.7-flash-AWQ
+# This mod applied MLA patch, but doesn't apply after vllm 0.14.1
+#mods:
+#  - mods/fix-glm-4.7-flash-AWQ
 
 defaults:
   port: 8000


### PR DESCRIPTION
This pull request makes minor updates to the `glm-4.7-flash-awq-vllm.yaml` configuration file, mainly cleaning up metadata and removing unused or obsolete settings.

Configuration cleanup:

* Removed the `mods/fix-glm-4.7-flash-AWQ` mod from the configuration and updated the description to reflect that the speed optimization patch is no longer applied after vllm 0.14.1.
* Removed the `served_model_name` default and its usage in the command, as it is no longer needed.