### PR TITLE
feat: add Atlas runtime recipes for the catalogued GB10 model lineup

### DIFF
--- a/official-recipes/gemma4/atlas/gemma-4-26b-a4b-nvfp4-atlas.yaml
+++ b/official-recipes/gemma4/atlas/gemma-4-26b-a4b-nvfp4-atlas.yaml
@@ -1,0 +1,25 @@
+recipe_version: "2"
+model: bg-digitalservices/Gemma-4-26B-A4B-it-NVFP4A16
+runtime: atlas
+container: avarok/atlas-gb10:latest
+max_nodes: 1
+
+metadata:
+  description: |
+    Gemma-4-26B-A4B — Google's hybrid Attention + MoE Gemma-4 with GeGLU
+    activations. ~67 tok/s decode on a single GB10 per the Atlas
+    performance table (`scripts/sweep_all_models.sh` baseline).
+  maintainer: avarok
+  category: agent
+  model_params: 26B
+  model_dtype: nvfp4
+  quantization: nvfp4
+  kv_dtype: fp8
+
+defaults:
+  port: 8888
+  host: 0.0.0.0
+  max_model_len: 8192
+  kv_cache_dtype: fp8
+  gpu_memory_utilization: 0.88
+  scheduling_policy: slai

--- a/official-recipes/gemma4/atlas/gemma-4-31b-nvfp4-atlas.yaml
+++ b/official-recipes/gemma4/atlas/gemma-4-31b-nvfp4-atlas.yaml
@@ -1,0 +1,38 @@
+recipe_version: "2"
+model: nvidia/Gemma-4-31B-IT-NVFP4
+runtime: atlas
+container: avarok/atlas-gb10:latest
+max_nodes: 1
+
+metadata:
+  description: |
+    Gemma-4-31B (dense) — Google Gemma-4 with sliding + full attention
+    and GeGLU. Atlas's `scripts/sweep_all_models.sh` runs this with
+    `--kv-cache-dtype fp8 --max-batch-size 2`; ~9 tok/s decode per the
+    Atlas performance table.
+
+    Production notes from the Atlas Gemma-4 fix campaign (2026-04-08
+    kernel dispatch + 2026-05-01 v_norm/lm_head/o_proj fixes):
+    long-context up to 16K passes cleanly, factual + simple-code +
+    word-math prompts are coherent at greedy. Greedy creative
+    generation (haiku, free-form) can drift into low-entropy repetition
+    after 3–5 lines — clients are encouraged to send `min_p: 0.05` and
+    `repetition_penalty: 1.1` for creative workloads. The native
+    Gemma-4 tool-call format (`<|tool_call>call:fn{...}<tool_call|>`)
+    is parsed when `tool_call_parser: gemma4` is set.
+  maintainer: avarok
+  category: agent
+  model_params: 31B
+  model_dtype: nvfp4
+  quantization: nvfp4
+  kv_dtype: fp8
+
+defaults:
+  port: 8888
+  host: 0.0.0.0
+  max_model_len: 8192
+  kv_cache_dtype: fp8
+  gpu_memory_utilization: 0.88
+  scheduling_policy: slai
+  max_batch_size: 2
+  tool_call_parser: gemma4

--- a/official-recipes/minimax-m2.7/atlas/minimax-m2.7-nvfp4-ep2-atlas.yaml
+++ b/official-recipes/minimax-m2.7/atlas/minimax-m2.7-nvfp4-ep2-atlas.yaml
@@ -24,7 +24,11 @@ defaults:
   host: 0.0.0.0
   tensor_parallel: 1
   ep_size: 2
-  max_model_len: 16384
+  # 12288 (not 16384) — at gpu_memory_utilization 0.90 the head only fits
+  # 13120 KV tokens (820 blocks × 16) after weights + MoE setup on
+  # avarok/atlas-gb10:latest (3.0.0). Live-validated 2026-05-08 on the
+  # 10.10.10.1/10.10.10.2 GB10 pair.
+  max_model_len: 12288
   max_batch_size: 1
   kv_cache_dtype: bf16
   gpu_memory_utilization: 0.90

--- a/official-recipes/minimax-m2.7/atlas/minimax-m2.7-nvfp4-ep2-atlas.yaml
+++ b/official-recipes/minimax-m2.7/atlas/minimax-m2.7-nvfp4-ep2-atlas.yaml
@@ -1,0 +1,32 @@
+recipe_version: "2"
+model: lukealonso/MiniMax-M2.7-NVFP4
+runtime: atlas
+container: avarok/atlas-gb10:latest
+min_nodes: 2
+max_nodes: 2
+
+metadata:
+  description: |
+    MiniMax M2.7 NVFP4 with expert parallelism across two GB10 nodes.
+    The validated production EP=2 configuration from Atlas's
+    `scripts/start-minimax-ep2.sh` — KV cache stays at BF16 during
+    bring-up (FP8/NVFP4 are not yet stable for MiniMax) and `--speculative`
+    is OFF because the public checkpoint ships no MTP weights.
+  maintainer: avarok
+  category: agent
+  model_params: 230B
+  model_dtype: nvfp4
+  quantization: nvfp4
+  kv_dtype: bf16
+
+defaults:
+  port: 8888
+  host: 0.0.0.0
+  tensor_parallel: 1
+  ep_size: 2
+  max_model_len: 16384
+  max_batch_size: 1
+  kv_cache_dtype: bf16
+  gpu_memory_utilization: 0.90
+  enable_prefix_caching: true
+  oom_guard_mb: 512

--- a/official-recipes/mistral-small-4/atlas/mistral-small-4-119b-nvfp4-atlas.yaml
+++ b/official-recipes/mistral-small-4/atlas/mistral-small-4-119b-nvfp4-atlas.yaml
@@ -1,0 +1,39 @@
+recipe_version: "2"
+model: mistralai/Mistral-Small-4-119B-2603-NVFP4
+runtime: atlas
+container: avarok/atlas-gb10:latest
+max_nodes: 1
+
+metadata:
+  description: |
+    Mistral-Small-4-119B — MLA (Multi-head Latent Attention,
+    `kv_lora_rank=256`, `qk_nope_head_dim=64`, `qk_rope_head_dim=64`,
+    `v_head_dim=128`) + 128 experts top-4 + 1 shared expert. ~33 tok/s
+    decode per the Atlas performance table.
+
+    Hard production constraints from the Atlas Mistral bring-up
+    (alpha-2.8 onward, two RoPE bugs fixed 2026-04-10):
+      * **MUST use `kv_cache_dtype: bf16`** — FP8/NVFP4 KV with the
+        default scale destroys the MLA compressed latent. The Atlas
+        2.8 release announcement called this out explicitly.
+      * MLA needs a `zero_all` before every decode step (gated
+        internally on `kv_lora_rank > 0`); CUDA graphs are suppressed
+        on this model because the memset is captured and throws on
+        replay. No tuning required from the user.
+
+    Known limitation: symbolic math ("2+2") less reliable than word
+    math ("two plus two") — model quirk.
+  maintainer: avarok
+  category: agent
+  model_params: 119B
+  model_dtype: nvfp4
+  quantization: nvfp4
+  kv_dtype: bf16
+
+defaults:
+  port: 8888
+  host: 0.0.0.0
+  max_model_len: 8192
+  kv_cache_dtype: bf16
+  gpu_memory_utilization: 0.88
+  scheduling_policy: slai

--- a/official-recipes/nemotron-3-nano/atlas/nemotron-3-nano-30b-a3b-nvfp4-atlas.yaml
+++ b/official-recipes/nemotron-3-nano/atlas/nemotron-3-nano-30b-a3b-nvfp4-atlas.yaml
@@ -1,0 +1,26 @@
+recipe_version: "2"
+model: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4
+runtime: atlas
+container: avarok/atlas-gb10:latest
+max_nodes: 1
+
+metadata:
+  description: |
+    Nemotron-3-Nano-30B-A3B — NVIDIA hybrid Mamba-2 + MoE + Attention
+    (52 layers in `MEMEMEM*EMEMEMEM*...` pattern, 128 experts top-6,
+    sigmoid routing). ~88-100 tok/s decode per the Atlas performance
+    table (FP8 KV). No MTP support.
+  maintainer: avarok
+  category: agent
+  model_params: 30B
+  model_dtype: nvfp4
+  quantization: nvfp4
+  kv_dtype: nvfp4
+
+defaults:
+  port: 8888
+  host: 0.0.0.0
+  max_model_len: 8192
+  kv_cache_dtype: nvfp4
+  gpu_memory_utilization: 0.88
+  scheduling_policy: slai

--- a/official-recipes/nemotron-3-super/atlas/nemotron-3-super-120b-a12b-nvfp4-atlas.yaml
+++ b/official-recipes/nemotron-3-super/atlas/nemotron-3-super-120b-a12b-nvfp4-atlas.yaml
@@ -1,0 +1,29 @@
+recipe_version: "2"
+model: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4
+runtime: atlas
+container: avarok/atlas-gb10:latest
+max_nodes: 1
+
+metadata:
+  description: |
+    Nemotron-3-Super-120B (A12B MoE) NVFP4 — NVIDIA's hybrid Mamba-2 +
+    MoE + Attention model on a single GB10. Single-node configuration
+    from the Atlas alpha-2.7 release announcement.
+  maintainer: avarok
+  category: agent
+  model_params: 120B
+  model_dtype: nvfp4
+  quantization: nvfp4
+  kv_dtype: fp8
+
+defaults:
+  port: 8888
+  host: 0.0.0.0
+  max_model_len: 65536
+  kv_cache_dtype: fp8
+  kv_high_precision_layers: auto
+  gpu_memory_utilization: 0.92
+  scheduling_policy: slai
+  tool_call_parser: qwen3_coder
+  ssm_cache_slots: 0
+  speculative: true

--- a/official-recipes/qwen3-coder-next/atlas/qwen3-coder-next-fp8-atlas.yaml
+++ b/official-recipes/qwen3-coder-next/atlas/qwen3-coder-next-fp8-atlas.yaml
@@ -1,0 +1,42 @@
+recipe_version: "2"
+model: Qwen/Qwen3-Coder-Next-FP8
+runtime: atlas
+container: avarok/atlas-gb10:latest
+max_nodes: 1
+
+metadata:
+  description: |
+    Qwen3-Coder-Next-FP8 — 80B MoE (512 experts top-10) with hybrid
+    GDN + Attention, served at native FP8 (~58 tok/s decode on a single
+    GB10 with no conversion overhead). Same architecture as
+    qwen3_next, only `rope_theta=5M` differs.
+
+    Production constraints from the Atlas FP8-native bring-up:
+      * `kv_cache_dtype: bf16` — FP8 KV is incompatible with this model
+      * `ssm_cache_slots: 0` — Marconi snapshot lookup misses cause SSM
+        state divergence in multi-turn
+      * `oom_guard_mb: 1024` — the default 4096 is too conservative for
+        FP8 (1.5× overhead estimate + 4 GB reserve > available)
+      * `tool_call_parser: qwen3_coder` — required for tool calling
+
+    Known limitation: agentic quality degrades after ~5–8 tool-use
+    turns (model emits malformed XML, loops). Document but accept —
+    this is a model issue, not an Atlas one.
+  maintainer: avarok
+  category: agent
+  model_params: 80B
+  model_dtype: fp8
+  quantization: fp8
+  kv_dtype: bf16
+
+defaults:
+  port: 8888
+  host: 0.0.0.0
+  max_model_len: 16384
+  max_batch_size: 1
+  kv_cache_dtype: bf16
+  gpu_memory_utilization: 0.92
+  scheduling_policy: slai
+  ssm_cache_slots: 0
+  oom_guard_mb: 1024
+  tool_call_parser: qwen3_coder

--- a/official-recipes/qwen3-next/atlas/qwen3-next-80b-a3b-nvfp4-atlas.yaml
+++ b/official-recipes/qwen3-next/atlas/qwen3-next-80b-a3b-nvfp4-atlas.yaml
@@ -1,0 +1,28 @@
+recipe_version: "2"
+model: nvidia/Qwen3-Next-80B-A3B-Instruct-NVFP4
+runtime: atlas
+container: avarok/atlas-gb10:latest
+max_nodes: 1
+
+metadata:
+  description: |
+    Qwen3-Next-80B (A3B MoE, hybrid SSM+Attention+MoE) NVFP4 + MTP —
+    largest single-node MoE model with MTP per the Atlas catalogue
+    (~104 tok/s decode at concurrency=1, ISL=128, OSL=128).
+  maintainer: avarok
+  category: agent
+  model_params: 80B
+  model_dtype: nvfp4
+  quantization: nvfp4
+  kv_dtype: nvfp4
+
+defaults:
+  port: 8888
+  host: 0.0.0.0
+  max_model_len: 8192
+  kv_cache_dtype: nvfp4
+  gpu_memory_utilization: 0.88
+  scheduling_policy: slai
+  speculative: true
+  mtp_quantization: nvfp4
+  enable_prefix_caching: true

--- a/official-recipes/qwen3-vl/atlas/qwen3-vl-30b-a3b-nvfp4-atlas.yaml
+++ b/official-recipes/qwen3-vl/atlas/qwen3-vl-30b-a3b-nvfp4-atlas.yaml
@@ -1,0 +1,27 @@
+recipe_version: "2"
+model: ig1/Qwen3-VL-30B-A3B-Instruct-NVFP4
+runtime: atlas
+container: avarok/atlas-gb10:latest
+max_nodes: 1
+
+metadata:
+  description: |
+    Qwen3-VL-30B-A3B vision-language model — pure attention (48 layers,
+    NO SSM, head_dim=128, ungated Q), MoE without shared experts.
+    Accepts images in OpenAI content-parts format (`{"type":
+    "image_url", "image_url": {"url": "data:image/jpeg;base64,..."}}`).
+    ~97 tok/s decode per the Atlas performance table (NVFP4 KV).
+  maintainer: avarok
+  category: vision
+  model_params: 30B
+  model_dtype: nvfp4
+  quantization: nvfp4
+  kv_dtype: nvfp4
+
+defaults:
+  port: 8888
+  host: 0.0.0.0
+  max_model_len: 32768
+  kv_cache_dtype: nvfp4
+  gpu_memory_utilization: 0.88
+  scheduling_policy: slai

--- a/official-recipes/qwen3.5/atlas/qwen3.5-122b-a10b-nvfp4-ep2-atlas.yaml
+++ b/official-recipes/qwen3.5/atlas/qwen3.5-122b-a10b-nvfp4-ep2-atlas.yaml
@@ -1,0 +1,32 @@
+recipe_version: "2"
+model: Sehyo/Qwen3.5-122B-A10B-NVFP4
+runtime: atlas
+container: avarok/atlas-gb10:latest
+min_nodes: 2
+max_nodes: 2
+
+metadata:
+  description: |
+    Qwen3.5-122B (A10B MoE) NVFP4, expert parallelism across two GB10 nodes
+    via NCCL over RoCEv2. Validated end-to-end at ~51 tok/s decode (Atlas
+    QUICKSTART). Both ranks must carry the same `--speculative` and
+    `--mtp-quantization` flags — the worker's MTP verify lands in the SSM
+    layer otherwise (Atlas-internal tracking: feedback_ep2_mtp_flags).
+  maintainer: avarok
+  category: agent
+  model_params: 122B
+  model_dtype: nvfp4
+  quantization: nvfp4
+  kv_dtype: nvfp4
+
+defaults:
+  port: 8888
+  host: 0.0.0.0
+  ep_size: 2
+  max_model_len: 4096
+  max_batch_size: 1
+  kv_cache_dtype: nvfp4
+  gpu_memory_utilization: 0.70
+  scheduling_policy: slai
+  speculative: true
+  mtp_quantization: nvfp4

--- a/official-recipes/qwen3.5/atlas/qwen3.5-122b-a10b-nvfp4-single-atlas.yaml
+++ b/official-recipes/qwen3.5/atlas/qwen3.5-122b-a10b-nvfp4-single-atlas.yaml
@@ -1,0 +1,34 @@
+recipe_version: "2"
+model: Sehyo/Qwen3.5-122B-A10B-NVFP4
+runtime: atlas
+container: avarok/atlas-gb10:latest
+max_nodes: 1
+
+metadata:
+  description: |
+    Qwen3.5-122B (A10B MoE) NVFP4, single GB10 (all 256 experts on one node).
+    The NVFP4 checkpoint is ~81 GB on disk; after Atlas's buffer arena, dequant
+    scratch, MoE routing state, and CUDA context, ~1.5–2 GB headroom remains
+    for KV cache. `--max-num-seqs` and `--max-seq-len` therefore stay tight.
+    Verified single-call decode 33.4 tok/s at batch=1; 4-way concurrent
+    requests serve cleanly per Atlas QUICKSTART.
+  maintainer: avarok
+  category: agent
+  model_params: 122B
+  model_dtype: nvfp4
+  quantization: nvfp4
+  kv_dtype: fp8
+
+defaults:
+  port: 8888
+  host: 0.0.0.0
+  max_model_len: 16384
+  kv_cache_dtype: fp8
+  kv_high_precision_layers: auto
+  gpu_memory_utilization: 0.92
+  scheduling_policy: slai
+  max_batch_size: 1
+  max_num_seqs: 4
+  oom_guard_mb: 1024
+  ssm_cache_slots: 0
+  tool_call_parser: qwen3_coder

--- a/official-recipes/qwen3.5/atlas/qwen3.5-27b-dense-nvfp4-atlas.yaml
+++ b/official-recipes/qwen3.5/atlas/qwen3.5-27b-dense-nvfp4-atlas.yaml
@@ -1,0 +1,33 @@
+recipe_version: "2"
+model: Kbenkhaled/Qwen3.5-27B-NVFP4
+runtime: atlas
+container: avarok/atlas-gb10:latest
+max_nodes: 1
+
+metadata:
+  description: |
+    Qwen3.5-27B Dense — hybrid SSM + Attention, no MoE, no MTP.
+    Best for quality-sensitive tasks where throughput is less critical
+    (~14 tok/s decode at concurrency=1 per the Atlas QUICKSTART).
+
+    Note: the dense Qwen 27B variants (3.5 and 3.6) have a known
+    post-`</think>` repetition attractor on long-code prompts (chess-game
+    stress sweep, 2026-05-05). Atlas ships with `enable_loop_watchdog =
+    true` for these models in MODEL.toml — the period-N sentence-
+    repetition detector in the scheduler catches it and ends generation
+    cleanly. If you see `finish_reason: "length"` at low token counts on
+    a repetitive output, that's the watchdog firing.
+  maintainer: avarok
+  category: agent
+  model_params: 27B
+  model_dtype: nvfp4
+  quantization: nvfp4
+  kv_dtype: nvfp4
+
+defaults:
+  port: 8888
+  host: 0.0.0.0
+  max_model_len: 8192
+  kv_cache_dtype: nvfp4
+  gpu_memory_utilization: 0.88
+  scheduling_policy: slai

--- a/official-recipes/qwen3.5/atlas/qwen3.5-35b-a3b-nvfp4-atlas.yaml
+++ b/official-recipes/qwen3.5/atlas/qwen3.5-35b-a3b-nvfp4-atlas.yaml
@@ -1,0 +1,28 @@
+recipe_version: "2"
+model: Sehyo/Qwen3.5-35B-A3B-NVFP4
+runtime: atlas
+container: avarok/atlas-gb10:latest
+max_nodes: 1
+
+metadata:
+  description: |
+    Qwen3.5-35B (A3B MoE) NVFP4 + MTP — Atlas's fastest catalogued model
+    on a single GB10 (~133 tok/s decode at concurrency=1, ISL=128, OSL=128
+    per the avarok/atlas-gb10 QUICKSTART).
+  maintainer: avarok
+  category: agent
+  model_params: 35B
+  model_dtype: nvfp4
+  quantization: nvfp4
+  kv_dtype: nvfp4
+
+defaults:
+  port: 8888
+  host: 0.0.0.0
+  max_model_len: 8192
+  kv_cache_dtype: nvfp4
+  gpu_memory_utilization: 0.88
+  scheduling_policy: slai
+  speculative: true
+  mtp_quantization: nvfp4
+  enable_prefix_caching: true


### PR DESCRIPTION
## Summary

Adds 13 recipes (one per `official-recipes/<family>/atlas/`) covering every model in the public Atlas Spark catalogue (`avarok/atlas-gb10:latest`). Sources: Atlas's QUICKSTART, the README performance table, `scripts/sweep_all_models.sh`, `scripts/start-minimax-ep2.sh`, and the release announcements in the Atlas-Inference Discord.

## Recipes

| Path | Source / notes |
|---|---|
| `qwen3.5/atlas/qwen3.5-27b-dense-nvfp4-atlas.yaml` | Atlas QUICKSTART §1 — dense hybrid SSM+Attn (~14 tok/s); description notes the post-`</think>` watchdog enabled in MODEL.toml |
| `qwen3.5/atlas/qwen3.5-35b-a3b-nvfp4-atlas.yaml` | QUICKSTART §4 — fastest model (~131 tok/s, MTP K=2) |
| `qwen3.5/atlas/qwen3.5-122b-a10b-nvfp4-single-atlas.yaml` | QUICKSTART §6 — strict KV/seq budget for all-experts-on-one-GB10 |
| `qwen3.5/atlas/qwen3.5-122b-a10b-nvfp4-ep2-atlas.yaml` | QUICKSTART §7 — EP=2 + MTP, both ranks carry matching `--speculative` + `--mtp-quantization nvfp4` per the documented bring-up constraint |
| `qwen3-next/atlas/qwen3-next-80b-a3b-nvfp4-atlas.yaml` | QUICKSTART §5 (~74-104 tok/s) |
| `qwen3-vl/atlas/qwen3-vl-30b-a3b-nvfp4-atlas.yaml` | QUICKSTART §2 — vision (~97 tok/s) |
| `qwen3-coder-next/atlas/qwen3-coder-next-fp8-atlas.yaml` | Atlas FP8-native bring-up — `kv_cache_dtype: bf16`, `ssm_cache_slots: 0`, `oom_guard_mb: 1024` (production-validated) |
| `gemma4/atlas/gemma-4-26b-a4b-nvfp4-atlas.yaml` | README perf table + `sweep_all_models.sh` (~67 tok/s) |
| `gemma4/atlas/gemma-4-31b-nvfp4-atlas.yaml` | Sets `tool_call_parser: gemma4`; description documents the `min_p`/`repetition_penalty` recommendation for greedy creative prompts |
| `nemotron-3-nano/atlas/nemotron-3-nano-30b-a3b-nvfp4-atlas.yaml` | QUICKSTART §3 — Mamba-2+MoE (~88 tok/s) |
| `nemotron-3-super/atlas/nemotron-3-super-120b-a12b-nvfp4-atlas.yaml` | alpha-2.7 release announcement — LatentMoE (~24 tok/s) |
| `mistral-small-4/atlas/mistral-small-4-119b-nvfp4-atlas.yaml` | **`kv_cache_dtype: bf16` is mandatory** — FP8/NVFP4 KV destroys the MLA compressed latent (alpha-2.8 release announcement) |
| `minimax-m2.7/atlas/minimax-m2.7-nvfp4-ep2-atlas.yaml` | Mirrors `start-minimax-ep2.sh` — BF16 KV during bring-up, `--speculative` OFF (no MTP weights in the public checkpoint) |

## Test plan

- [x] All 13 recipes load via `Recipe.from_dict()` and render commands matching the published Atlas examples (verified end-to-end against the `AtlasRuntime` plugin from the sibling sparkrun PR)
- [x] EP=2 recipes correctly produce `--rank 0 --world-size 2 --master-addr <ip> --master-port 29500` for the head and `--port 0 --rank 1 …` for the worker
- [ ] Live launch via `sparkrun run @official/<recipe>` against `avarok/atlas-gb10:latest` on a GB10 (manual verification)

## Required upstream change

These recipes need the `atlas` runtime registered, which is in **spark-arena/sparkrun#feature/atlas-runtime** (sibling PR).