### PR TITLE
fix: DeepSeek v4 Flash image build

### DIFF
--- a/experimental-recipes/deepseek4/deepseek4-flash-fp8-mtp-vllm.yaml
+++ b/experimental-recipes/deepseek4/deepseek4-flash-fp8-mtp-vllm.yaml
@@ -1,15 +1,15 @@
 recipe_version: "2"
 model: deepseek-ai/DeepSeek-V4-Flash
 runtime: vllm
-container: sparkrun-vllm-deepseek4-20260517
+container: sparkrun-vllm-deepseek4-20260519
 min_nodes: 2
 
 metadata:
   description: DeepSeek-V4-Flash
 
-build_args: # updated 20260517
-  - "--vllm-ref"
-  - "refs/pull/41834/head"
+build_args: # updated 20260519
+  - "--apply-vllm-pr"
+  - "41834"
 
 mods:
   - "mods/drop-caches"

--- a/experimental-recipes/deepseek4/deepseek4-flash-fp8-vllm.yaml
+++ b/experimental-recipes/deepseek4/deepseek4-flash-fp8-vllm.yaml
@@ -1,15 +1,15 @@
 recipe_version: "2"
 model: deepseek-ai/DeepSeek-V4-Flash
 runtime: vllm
-container: sparkrun-vllm-deepseek4-20260517
+container: sparkrun-vllm-deepseek4-20260519
 min_nodes: 2
 
 metadata:
   description: DeepSeek-V4-Flash
 
-build_args: # updated 20260517
-  - "--vllm-ref"
-  - "refs/pull/41834/head"
+build_args: # updated 20260519
+  - "--apply-vllm-pr"
+  - "41834"
 
 mods:
   - "mods/drop-caches"


### PR DESCRIPTION
### Description

This change fixes the DeepSeek v4 Flash vLLM image build by correcting how the vLLM pull request is applied during Docker builds.

### Change

Replaces:

`--vllm-ref refs/pull/41834/head`

with:

`--apply-vllm-pr 41834`

### Problem

The previous configuration attempted to checkout a GitHub PR ref directly:

`refs/pull/41834/head`

This reference is not reliably available as a local ref inside the image build environment, causing Git checkout to fail.

### Observed build failure
```
error: pathspec 'refs/pull/41834/head' did not match any file(s) known to git
failed to solve: process "/bin/sh -c cd /repo-cache && ..." did not complete successfully: exit code: 1
```
This breaks the Docker image build during the vLLM source checkout step.

### Solution

Switch to the supported PR application mechanism:

`--apply-vllm-pr`